### PR TITLE
feat: make dashboard hero/banner data dynamic from backend

### DIFF
--- a/backend/src/handlers/dashboard_handler.rs
+++ b/backend/src/handlers/dashboard_handler.rs
@@ -1,6 +1,6 @@
 use crate::state::AppState;
 use axum::{extract::State, http::StatusCode, Json};
-use shared::{DashboardStats, RevenuePoint};
+use shared::{BatchSummary, DashboardStats, RevenuePoint};
 use sqlx::Row;
 
 pub async fn stats(
@@ -55,6 +55,43 @@ pub async fn revenue(
         .collect();
 
     Ok(Json(points))
+}
+
+pub async fn batch_summary(
+    State(state): State<AppState>,
+) -> Result<Json<BatchSummary>, (StatusCode, String)> {
+    let row = sqlx::query(
+        r#"
+        SELECT
+            batch_number,
+            total_batches,
+            claimed_spots,
+            total_spots,
+            spots_left,
+            tier_name,
+            founder_name,
+            founder_avatar_url,
+            cta_url
+        FROM batch_summary
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&state.pool)
+    .await
+    .map_err(internal_error)?;
+
+    Ok(Json(BatchSummary {
+        batch_number: row.get("batch_number"),
+        total_batches: row.get("total_batches"),
+        claimed_spots: row.get("claimed_spots"),
+        total_spots: row.get("total_spots"),
+        spots_left: row.get("spots_left"),
+        tier_name: row.get("tier_name"),
+        founder_name: row.get("founder_name"),
+        founder_avatar_url: row.get("founder_avatar_url"),
+        cta_url: row.get("cta_url"),
+    }))
 }
 
 fn internal_error(error: sqlx::Error) -> (StatusCode, String) {

--- a/backend/src/routes/dashboard.rs
+++ b/backend/src/routes/dashboard.rs
@@ -5,4 +5,5 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/stats", get(dashboard_handler::stats))
         .route("/revenue", get(dashboard_handler::revenue))
+        .route("/batch-summary", get(dashboard_handler::batch_summary))
 }

--- a/frontend/src/api/client.rs
+++ b/frontend/src/api/client.rs
@@ -1,5 +1,5 @@
 use reqwasm::http::Request;
-use shared::{DashboardStats, RevenuePoint};
+use shared::{BatchSummary, DashboardStats, RevenuePoint};
 
 const API_BASE: &str = "/api";
 
@@ -9,6 +9,10 @@ pub async fn fetch_stats() -> Result<DashboardStats, String> {
 
 pub async fn fetch_revenue() -> Result<Vec<RevenuePoint>, String> {
     fetch_json(&format!("{API_BASE}/dashboard/revenue")).await
+}
+
+pub async fn fetch_batch_summary() -> Result<BatchSummary, String> {
+    fetch_json(&format!("{API_BASE}/dashboard/batch-summary")).await
 }
 
 async fn fetch_json<T>(url: &str) -> Result<T, String>

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::client::{fetch_revenue, fetch_stats},
+    api::client::{fetch_batch_summary, fetch_revenue, fetch_stats},
     components::{simple_chart::SimpleChart, stat_card::StatCard},
 };
 use leptos::*;
@@ -8,6 +8,7 @@ use leptos::*;
 pub fn DashboardPage() -> impl IntoView {
     let stats = create_resource(|| (), |_| async { fetch_stats().await });
     let revenue = create_resource(|| (), |_| async { fetch_revenue().await });
+    let batch = create_resource(|| (), |_| async { fetch_batch_summary().await });
     let (dark_mode, set_dark_mode) = create_signal(true);
 
     view! {
@@ -35,14 +36,41 @@ pub fn DashboardPage() -> impl IntoView {
                         <h1 class="m-0 max-w-[900px] text-[clamp(2.45rem,6vw,6.4rem)] font-black leading-[0.88] tracking-normal">"The place that sharpens your taste."</h1>
                     </div>
                     <div class="flex shrink-0 items-center gap-2.5 max-sm:w-full max-sm:justify-between">
-                        <a
-                            class="inline-flex min-h-9 items-center justify-center whitespace-nowrap rounded-full border border-red-400 bg-shipper-red px-4 text-[0.82rem] font-extrabold text-white shadow-[0_14px_34px_rgb(225_29_29_/_0.26)] hover:bg-red-500"
-                            href="https://www.shipper.club/"
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            "Claim your spot"
-                        </a>
+                        <Suspense fallback=move || view! {
+                            <a
+                                class="inline-flex min-h-9 items-center justify-center whitespace-nowrap rounded-full border border-red-400 bg-shipper-red px-4 text-[0.82rem] font-extrabold text-white shadow-[0_14px_34px_rgb(225_29_29_/_0.26)] hover:bg-red-500"
+                                href="https://www.shipper.club/"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                "Claim your spot"
+                            </a>
+                        }>
+                            {move || {
+                                batch.get().map(|result| match result {
+                                    Ok(b) => view! {
+                                        <a
+                                            class="inline-flex min-h-9 items-center justify-center whitespace-nowrap rounded-full border border-red-400 bg-shipper-red px-4 text-[0.82rem] font-extrabold text-white shadow-[0_14px_34px_rgb(225_29_29_/_0.26)] hover:bg-red-500"
+                                            href={b.cta_url.clone()}
+                                            target="_blank"
+                                            rel="noreferrer"
+                                        >
+                                            "Claim your spot"
+                                        </a>
+                                    }.into_view(),
+                                    Err(_) => view! {
+                                        <a
+                                            class="inline-flex min-h-9 items-center justify-center whitespace-nowrap rounded-full border border-red-400 bg-shipper-red px-4 text-[0.82rem] font-extrabold text-white shadow-[0_14px_34px_rgb(225_29_29_/_0.26)] hover:bg-red-500"
+                                            href="https://www.shipper.club/"
+                                            target="_blank"
+                                            rel="noreferrer"
+                                        >
+                                            "Claim your spot"
+                                        </a>
+                                    }.into_view(),
+                                })
+                            }}
+                        </Suspense>
                         <div class="flex rounded-full border border-zinc-200 bg-white/80 p-1 dark:border-zinc-800 dark:bg-zinc-950/80" role="group" aria-label="Theme">
                             <button
                                 type="button"
@@ -75,26 +103,49 @@ pub fn DashboardPage() -> impl IntoView {
                     </div>
                 </header>
 
-                <div class="mb-3.5 grid grid-cols-[1fr_auto_auto] items-center gap-3 rounded-lg bg-zinc-950 p-5 text-white shadow-[0_18px_60px_rgb(10_10_10_/_0.12)] dark:bg-white dark:text-black dark:shadow-[0_22px_70px_rgb(0_0_0_/_0.44)] max-lg:grid-cols-1 max-lg:items-start">
-                    <div>
-                        <p class="m-0 mb-1 text-[0.88rem] font-bold text-white/70 dark:text-black/65">"Current batch - become a Legend"</p>
-                        <span class="text-[0.88rem] font-bold text-white/70 dark:text-black/65">"Batch 2 of 10 · 16/100 claimed"</span>
+                <Suspense fallback=move || view! {
+                    <div class="mb-3.5 grid grid-cols-[1fr_auto_auto] items-center gap-3 rounded-lg bg-zinc-950 p-5 text-white shadow-[0_18px_60px_rgb(10_10_10_/_0.12)] dark:bg-white dark:text-black dark:shadow-[0_22px_70px_rgb(0_0_0_/_0.44)] max-lg:grid-cols-1 max-lg:items-start">
+                        <p class="m-0 text-[0.88rem] font-bold text-white/70 dark:text-black/65">"Loading batch info…"</p>
                     </div>
-                    <strong class="text-[clamp(1.2rem,3vw,2.35rem)] font-black uppercase leading-none tracking-normal">"84 spots left"</strong>
-                    <div class="flex items-center gap-2.5 rounded-full border border-white/25 py-1.5 pl-1.5 pr-3 dark:border-black/20">
-                        <img
-                            class="block h-[42px] w-[42px] rounded-full border border-white/45 object-cover dark:border-black/35"
-                            src="https://www.shipper.club/builders/orcdev.jpeg"
-                            alt="OrcDev avatar"
-                            width="42"
-                            height="42"
-                        />
-                        <div class="grid gap-px">
-                            <span class="text-[0.68rem] font-bold uppercase text-white/70 dark:text-black/60">"Founded by"</span>
-                            <b class="text-[0.92rem] leading-none">"OrcDev"</b>
-                        </div>
-                    </div>
-                </div>
+                }>
+                    {move || {
+                        batch.get().map(|result| match result {
+                            Ok(b) => view! {
+                                <div class="mb-3.5 grid grid-cols-[1fr_auto_auto] items-center gap-3 rounded-lg bg-zinc-950 p-5 text-white shadow-[0_18px_60px_rgb(10_10_10_/_0.12)] dark:bg-white dark:text-black dark:shadow-[0_22px_70px_rgb(0_0_0_/_0.44)] max-lg:grid-cols-1 max-lg:items-start">
+                                    <div>
+                                        <p class="m-0 mb-1 text-[0.88rem] font-bold text-white/70 dark:text-black/65">
+                                            {format!("Current batch - become a {}", b.tier_name)}
+                                        </p>
+                                        <span class="text-[0.88rem] font-bold text-white/70 dark:text-black/65">
+                                            {format!("Batch {} of {} · {}/{} claimed", b.batch_number, b.total_batches, b.claimed_spots, b.total_spots)}
+                                        </span>
+                                    </div>
+                                    <strong class="text-[clamp(1.2rem,3vw,2.35rem)] font-black uppercase leading-none tracking-normal">
+                                        {format!("{} spots left", b.spots_left)}
+                                    </strong>
+                                    <div class="flex items-center gap-2.5 rounded-full border border-white/25 py-1.5 pl-1.5 pr-3 dark:border-black/20">
+                                        <img
+                                            class="block h-[42px] w-[42px] rounded-full border border-white/45 object-cover dark:border-black/35"
+                                            src={b.founder_avatar_url.clone()}
+                                            alt={format!("{} avatar", b.founder_name)}
+                                            width="42"
+                                            height="42"
+                                        />
+                                        <div class="grid gap-px">
+                                            <span class="text-[0.68rem] font-bold uppercase text-white/70 dark:text-black/60">"Founded by"</span>
+                                            <b class="text-[0.92rem] leading-none">{b.founder_name.clone()}</b>
+                                        </div>
+                                    </div>
+                                </div>
+                            }.into_view(),
+                            Err(error) => view! {
+                                <div class="mb-3.5 rounded-lg border border-red-400/30 bg-red-950/20 p-5">
+                                    <p class="m-0 text-[0.88rem] font-bold text-red-400">{format!("Failed to load batch info: {error}")}</p>
+                                </div>
+                            }.into_view(),
+                        })
+                    }}
+                </Suspense>
 
                 <Suspense fallback=move || view! { <p class="text-zinc-500 dark:text-zinc-400">"Loading dashboard..."</p> }>
                     {move || {

--- a/migrations/003_create_batch_summary.sql
+++ b/migrations/003_create_batch_summary.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS batch_summary (
+    id BIGSERIAL PRIMARY KEY,
+    batch_number BIGINT NOT NULL,
+    total_batches BIGINT NOT NULL,
+    claimed_spots BIGINT NOT NULL,
+    total_spots BIGINT NOT NULL,
+    spots_left BIGINT NOT NULL,
+    tier_name TEXT NOT NULL,
+    founder_name TEXT NOT NULL,
+    founder_avatar_url TEXT NOT NULL,
+    cta_url TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO batch_summary (
+    batch_number,
+    total_batches,
+    claimed_spots,
+    total_spots,
+    spots_left,
+    tier_name,
+    founder_name,
+    founder_avatar_url,
+    cta_url
+)
+VALUES (
+    2,
+    10,
+    16,
+    100,
+    84,
+    'Legend',
+    'OrcDev',
+    'https://www.shipper.club/builders/orcdev.jpeg',
+    'https://www.shipper.club/'
+)
+ON CONFLICT DO NOTHING;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod models;
 pub mod responses;
 
-pub use models::{DashboardStats, RevenuePoint};
+pub use models::{BatchSummary, DashboardStats, RevenuePoint};
 pub use responses::DashboardResponse;

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -15,3 +15,16 @@ pub struct RevenuePoint {
     pub date: NaiveDate,
     pub revenue_cents: i64,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BatchSummary {
+    pub batch_number: i64,
+    pub total_batches: i64,
+    pub claimed_spots: i64,
+    pub total_spots: i64,
+    pub spots_left: i64,
+    pub tier_name: String,
+    pub founder_name: String,
+    pub founder_avatar_url: String,
+    pub cta_url: String,
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded hero/banner values in the frontend dashboard with data fetched from a new backend endpoint.

Closes #1

## Changes

### Shared crate
- Added `BatchSummary` struct with 9 fields
- Re-exported from `shared::lib`

### Database
- New migration `003_create_batch_summary.sql`
- Creates `batch_summary` table with seed data matching current hardcoded values

### Backend
- New `batch_summary()` handler in `dashboard_handler.rs`
- New route: `GET /api/dashboard/batch-summary`

### Frontend
- New `fetch_batch_summary()` API function
- Dashboard hero/banner now uses API data
- Added loading state ("Loading batch info…")
- Added error state with styled error message
- CTA button URL is now dynamic

## Visual design

No visual changes — the banner looks identical, it's just data-driven now.

## Testing

- `cargo check -p shared -p backend` ✅
- `cargo check -p frontend --target wasm32-unknown-unknown` ✅
- `cargo fmt --all -- --check` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic batch summary to the dashboard displaying current tier, batch progress, available spots, and founder information
  * Updated the primary call-to-action to pull from live batch data instead of static defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->