### PR TITLE
feat: persist dark/light mode preference in localStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ name = "frontend"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
+ "js-sys",
  "leptos",
  "reqwasm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ axum = "0.7"
 chrono = { version = "0.4", features = ["serde"] }
 console_error_panic_hook = "0.1"
 dotenvy = "0.15"
+js-sys = "0.3"
 leptos = { version = "0.6", features = ["csr"] }
 reqwasm = "0.5"
 serde = { version = "1", features = ["derive"] }

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 
 [dependencies]
 console_error_panic_hook.workspace = true
+js-sys.workspace = true
 leptos.workspace = true
 reqwasm.workspace = true
 serde.workspace = true

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -8,7 +8,8 @@ use leptos::*;
 pub fn DashboardPage() -> impl IntoView {
     let stats = create_resource(|| (), |_| async { fetch_stats().await });
     let revenue = create_resource(|| (), |_| async { fetch_revenue().await });
-    let (dark_mode, set_dark_mode) = create_signal(true);
+    let initial_dark = get_theme_preference().map(|v| v != "light").unwrap_or(true);
+    let (dark_mode, set_dark_mode) = create_signal(initial_dark);
 
     view! {
         <style>{include_str!("../styles.css")}</style>
@@ -53,7 +54,10 @@ pub fn DashboardPage() -> impl IntoView {
                                         "min-w-14 cursor-pointer rounded-full bg-zinc-950 px-2.5 py-1.5 text-[0.8rem] font-bold text-white"
                                     }
                                 }
-                                on:click=move |_| set_dark_mode.set(false)
+                                on:click=move |_| {
+                                    set_dark_mode.set(false);
+                                    set_theme_preference("light");
+                                }
                             >
                                 "Light"
                             </button>
@@ -66,7 +70,10 @@ pub fn DashboardPage() -> impl IntoView {
                                         "min-w-14 cursor-pointer rounded-full px-2.5 py-1.5 text-[0.8rem] font-bold text-zinc-500"
                                     }
                                 }
-                                on:click=move |_| set_dark_mode.set(true)
+                                on:click=move |_| {
+                                    set_dark_mode.set(true);
+                                    set_theme_preference("dark");
+                                }
                             >
                                 "Dark"
                             </button>
@@ -137,4 +144,13 @@ pub fn DashboardPage() -> impl IntoView {
 
 fn format_cents(cents: i64) -> String {
     format!("${:.2}", cents as f64 / 100.0)
+}
+
+fn get_theme_preference() -> Option<String> {
+    let val = js_sys::eval("localStorage.getItem('shipper-theme')").ok()?;
+    val.as_string()
+}
+
+fn set_theme_preference(theme: &str) {
+    let _ = js_sys::eval(&format!("localStorage.setItem('shipper-theme','{theme}')"));
 }


### PR DESCRIPTION
## Summary

Persists the dark/light mode toggle in `localStorage` so the user's preference survives page reloads.

Closes #2

## Changes

- Read `shipper-theme` from `localStorage` on page load to initialise the signal
- Write `dark` or `light` to `localStorage` on toggle click
- Falls back to dark mode if no stored preference
- Added `js-sys` dependency for `localStorage` access via `js_sys::eval`

## Files changed

- `frontend/src/pages/dashboard.rs` — init + toggle logic
- `frontend/Cargo.toml` — added `js-sys`
- `Cargo.toml` (workspace) — added `js-sys`

## Testing

- `cargo check -p frontend --target wasm32-unknown-unknown` ✅
- `cargo fmt --all -- --check` ✅