### PR TITLE
feat: add date range filter to revenue chart endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "chrono",
  "dotenvy",
  "serde",
  "shared",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
+chrono.workspace = true
 dotenvy.workspace = true
 serde.workspace = true
 shared.workspace = true

--- a/backend/src/handlers/dashboard_handler.rs
+++ b/backend/src/handlers/dashboard_handler.rs
@@ -1,7 +1,19 @@
 use crate::state::AppState;
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::NaiveDate;
+use serde::Deserialize;
 use shared::{DashboardStats, RevenuePoint};
 use sqlx::Row;
+
+#[derive(Deserialize)]
+pub struct RevenueQuery {
+    pub from: Option<NaiveDate>,
+    pub to: Option<NaiveDate>,
+}
 
 pub async fn stats(
     State(state): State<AppState>,
@@ -34,14 +46,24 @@ pub async fn stats(
 
 pub async fn revenue(
     State(state): State<AppState>,
+    Query(params): Query<RevenueQuery>,
 ) -> Result<Json<Vec<RevenuePoint>>, (StatusCode, String)> {
+    let today = chrono::Utc::now().date_naive();
+    let from = params
+        .from
+        .unwrap_or_else(|| today - chrono::Duration::days(30));
+    let to = params.to.unwrap_or(today);
+
     let rows = sqlx::query(
         r#"
         SELECT date, revenue_cents
         FROM revenue_points
+        WHERE date >= $1 AND date <= $2
         ORDER BY date ASC
         "#,
     )
+    .bind(from)
+    .bind(to)
     .fetch_all(&state.pool)
     .await
     .map_err(internal_error)?;


### PR DESCRIPTION
## Summary

Adds optional `from` and `to` query parameters to the revenue endpoint so clients can request a specific date range.

Closes #3

## Usage

```
GET /api/dashboard/revenue                          # last 30 days (default)
GET /api/dashboard/revenue?from=2026-04-27&to=2026-05-02  # specific range
GET /api/dashboard/revenue?from=2026-04-27          # from date to today
```

## Changes

- Added `RevenueQuery` struct with optional `from`/`to` fields
- Revenue handler now accepts `Query<RevenueQuery>` extractor
- SQL query filters with `WHERE date >= $1 AND date <= $2`
- Defaults to last 30 days if no params provided
- Added `chrono` dependency to backend

## Backwards compatible

Existing calls without query params continue to work (returns last 30 days instead of all rows).

## Testing

- `cargo check -p backend` ✅
- `cargo fmt --all -- --check` ✅