### PR TITLE
chore: add automated migration runner on backend startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ reqwasm = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 shared = { path = "shared" }
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "chrono"] }
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "chrono", "migrate"] }
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.5", features = ["cors", "trace"] }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY Cargo.toml ./
 COPY backend ./backend
 COPY frontend ./frontend
+COPY migrations ./migrations
 COPY shared ./shared
 
 RUN cargo build --release -p backend

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -25,6 +25,13 @@ async fn main() -> anyhow::Result<()> {
     let bind_addr = env::var("BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:3000".to_string());
 
     let pool = create_pool(&database_url).await?;
+
+    sqlx::migrate!("../migrations")
+        .run(&pool)
+        .await
+        .context("failed to run database migrations")?;
+    tracing::info!("migrations applied successfully");
+
     let state = AppState { pool };
     let router = app::router(state);
 


### PR DESCRIPTION
## Summary

Runs database migrations automatically when the backend starts, removing the need to apply SQL files manually.

Closes #4

## Changes

- Enabled `migrate` feature on `sqlx` in workspace `Cargo.toml`
- Added `sqlx::migrate!("../migrations").run(&pool).await` in `main.rs` after pool creation
- Copies the repo-level `migrations/` directory into the backend Docker builder image so the SQLx migrate macro can embed migrations at compile time
- Logs success message after migrations are applied

## How it works

The `sqlx::migrate!()` macro embeds all `.sql` files from the `migrations/` directory at compile time. On startup, it creates a `_sqlx_migrations` tracking table and applies any pending migrations idempotently.

## Testing

- `cargo check -p backend`
- `cargo fmt --all -- --check`
- `docker compose build backend`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database migrations now automatically run on application startup, ensuring the database schema is properly initialized before the application starts serving requests
  * Enhanced deployment process with automatic database schema management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->