### PR TITLE
ci: add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy (backend)
+        run: cargo clippy -p shared -p backend -- -D warnings
+
+      - name: Check backend
+        run: cargo check -p shared -p backend
+
+      - name: Check frontend (wasm)
+        run: cargo check -p frontend --target wasm32-unknown-unknown


### PR DESCRIPTION
## Summary

Adds a CI pipeline that runs on every push to main and on all pull requests.

Closes #6

## Checks

1. **Format** — `cargo fmt --all -- --check`
2. **Clippy** — `cargo clippy -p shared -p backend -- -D warnings`
3. **Backend build** — `cargo check -p shared -p backend`
4. **Frontend build** — `cargo check -p frontend --target wasm32-unknown-unknown`

## Features

- Uses `dtolnay/rust-toolchain@stable` for Rust setup
- Installs `wasm32-unknown-unknown` target for frontend
- Uses `Swatinem/rust-cache@v2` for build caching

## Files

- `.github/workflows/ci.yml` — new file