### PR TITLE
fix: health endpoint should verify database connectivity

### DIFF
--- a/backend/src/routes/health.rs
+++ b/backend/src/routes/health.rs
@@ -1,5 +1,5 @@
 use crate::state::AppState;
-use axum::{routing::get, Json, Router};
+use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -11,6 +11,11 @@ pub fn router() -> Router<AppState> {
     Router::new().route("/health", get(health))
 }
 
-async fn health() -> Json<HealthResponse> {
-    Json(HealthResponse { status: "ok" })
+async fn health(State(state): State<AppState>) -> Result<Json<HealthResponse>, StatusCode> {
+    sqlx::query("SELECT 1")
+        .fetch_one(&state.pool)
+        .await
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+
+    Ok(Json(HealthResponse { status: "ok" }))
 }


### PR DESCRIPTION
## Summary

The health endpoint now verifies the database is reachable before reporting healthy.

Closes #8

## Before

`GET /api/health` always returned `200 {"status": "ok"}` even if the database was down.

## After

- Runs `SELECT 1` against the database
- Returns `200 {"status": "ok"}` if DB responds
- Returns `503 Service Unavailable` if DB is unreachable

## Changes

- `backend/src/routes/health.rs` — updated handler to accept `State<AppState>` and run a DB ping

## Testing

- `cargo check -p backend` ✅
- `cargo fmt --all -- --check` ✅
