### PR TITLE
a11y: improve keyboard navigation and ARIA labels

### DIFF
--- a/frontend/src/components/simple_chart.rs
+++ b/frontend/src/components/simple_chart.rs
@@ -13,19 +13,22 @@ pub fn SimpleChart(points: Vec<RevenuePoint>) -> impl IntoView {
     view! {
         <div
             class="grid h-[280px] grid-cols-[repeat(auto-fit,minmax(58px,1fr))] items-end gap-3 border-b border-zinc-300 pt-4 dark:border-zinc-700"
-            aria-label="Revenue over time chart"
+            role="img"
+            aria-label="Revenue over time bar chart"
         >
             {points.into_iter().map(|point| {
                 let height = ((point.revenue_cents as f64 / max_revenue as f64) * 100.0).max(8.0);
                 let revenue = format!("${:.0}", point.revenue_cents as f64 / 100.0);
+                let date_label = point.date.format("%b %-d").to_string();
+                let bar_label = format!("{date_label}: {revenue}");
                 view! {
-                    <div class="flex h-full min-w-0 flex-col items-center justify-end">
+                    <div class="flex h-full min-w-0 flex-col items-center justify-end" aria-label=bar_label>
                         <span class="mb-2 text-[0.72rem] font-extrabold text-zinc-500 dark:text-zinc-400">{revenue}</span>
                         <div
                             class="min-h-2 w-full rounded-t-lg bg-zinc-950 dark:bg-zinc-50"
                             style=format!("height: {height:.1}%")
                         ></div>
-                        <span class="mt-2 min-h-[18px] text-[0.76rem] font-bold text-zinc-500 dark:text-zinc-400">{point.date.format("%b %-d").to_string()}</span>
+                        <span class="mt-2 min-h-[18px] text-[0.76rem] font-bold text-zinc-500 dark:text-zinc-400">{date_label}</span>
                     </div>
                 }
             }).collect_view()}

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -40,6 +40,7 @@ pub fn DashboardPage() -> impl IntoView {
                             href="https://www.shipper.club/"
                             target="_blank"
                             rel="noreferrer"
+                            aria-label="Claim your spot at Shipper Club"
                         >
                             "Claim your spot"
                         </a>
@@ -53,6 +54,7 @@ pub fn DashboardPage() -> impl IntoView {
                                         "min-w-14 cursor-pointer rounded-full bg-zinc-950 px-2.5 py-1.5 text-[0.8rem] font-bold text-white"
                                     }
                                 }
+                                aria-pressed=move || if dark_mode.get() { "false" } else { "true" }
                                 on:click=move |_| set_dark_mode.set(false)
                             >
                                 "Light"
@@ -66,6 +68,7 @@ pub fn DashboardPage() -> impl IntoView {
                                         "min-w-14 cursor-pointer rounded-full px-2.5 py-1.5 text-[0.8rem] font-bold text-zinc-500"
                                     }
                                 }
+                                aria-pressed=move || if dark_mode.get() { "true" } else { "false" }
                                 on:click=move |_| set_dark_mode.set(true)
                             >
                                 "Dark"
@@ -75,7 +78,7 @@ pub fn DashboardPage() -> impl IntoView {
                     </div>
                 </header>
 
-                <div class="mb-3.5 grid grid-cols-[1fr_auto_auto] items-center gap-3 rounded-lg bg-zinc-950 p-5 text-white shadow-[0_18px_60px_rgb(10_10_10_/_0.12)] dark:bg-white dark:text-black dark:shadow-[0_22px_70px_rgb(0_0_0_/_0.44)] max-lg:grid-cols-1 max-lg:items-start">
+                <div class="mb-3.5 grid grid-cols-[1fr_auto_auto] items-center gap-3 rounded-lg bg-zinc-950 p-5 text-white shadow-[0_18px_60px_rgb(10_10_10_/_0.12)] dark:bg-white dark:text-black dark:shadow-[0_22px_70px_rgb(0_0_0_/_0.44)] max-lg:grid-cols-1 max-lg:items-start" role="region" aria-label="Current batch summary">
                     <div>
                         <p class="m-0 mb-1 text-[0.88rem] font-bold text-white/70 dark:text-black/65">"Current batch - become a Legend"</p>
                         <span class="text-[0.88rem] font-bold text-white/70 dark:text-black/65">"Batch 2 of 10 · 16/100 claimed"</span>
@@ -96,7 +99,8 @@ pub fn DashboardPage() -> impl IntoView {
                     </div>
                 </div>
 
-                <Suspense fallback=move || view! { <p class="text-zinc-500 dark:text-zinc-400">"Loading dashboard..."</p> }>
+                <div aria-live="polite">
+                <Suspense fallback=move || view! { <p class="text-zinc-500 dark:text-zinc-400">{"Loading dashboard..."}</p> }>
                     {move || {
                         stats.get().map(|result| match result {
                             Ok(stats) => view! {
@@ -112,8 +116,9 @@ pub fn DashboardPage() -> impl IntoView {
                         })
                     }}
                 </Suspense>
+                </div>
 
-                <section class="rounded-lg border border-zinc-200 bg-white/95 p-5 shadow-[0_18px_60px_rgb(10_10_10_/_0.08)] dark:border-zinc-800 dark:bg-zinc-950/95 dark:shadow-[0_22px_70px_rgb(0_0_0_/_0.44)]">
+                <section class="rounded-lg border border-zinc-200 bg-white/95 p-5 shadow-[0_18px_60px_rgb(10_10_10_/_0.08)] dark:border-zinc-800 dark:bg-zinc-950/95 dark:shadow-[0_22px_70px_rgb(0_0_0_/_0.44)]" aria-label="Revenue chart">
                     <div class="mb-5 flex items-start justify-between gap-3 max-sm:flex-col">
                         <div>
                             <p class="m-0 mb-2 text-xs font-extrabold uppercase tracking-normal text-zinc-500 dark:text-zinc-400">"Signal"</p>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -10,3 +10,10 @@ button,
 a {
   font: inherit;
 }
+
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid #e01d1d;
+  outline-offset: 2px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary

Improves accessibility across the dashboard with proper ARIA attributes and keyboard focus indicators.

Closes #11

## Changes

### Dashboard page
- `aria-pressed` on theme toggle buttons (reflects active state)
- `aria-label` on CTA link ("Claim your spot at Shipper Club")
- `role="region"` + `aria-label` on batch summary banner
- `aria-live="polite"` on dynamic content regions (stats Suspense)
- `aria-label` on revenue chart section

### Chart component
- `role="img"` on chart container
- `aria-label` on each bar with date and revenue (e.g. "Apr 27: $6400")

### Styles
- `focus-visible` outline on buttons and links for keyboard navigation

## Files changed

- `frontend/src/pages/dashboard.rs`
- `frontend/src/components/simple_chart.rs`
- `frontend/src/styles.css`

## Testing

- `cargo check -p frontend --target wasm32-unknown-unknown` ✅
- `cargo fmt --all -- --check` ✅