### PR TITLE
feat: add member list/table endpoint and UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "chrono",
  "dotenvy",
  "serde",
  "shared",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
+chrono.workspace = true
 dotenvy.workspace = true
 serde.workspace = true
 shared.workspace = true

--- a/backend/src/handlers/dashboard_handler.rs
+++ b/backend/src/handlers/dashboard_handler.rs
@@ -1,6 +1,6 @@
 use crate::state::AppState;
 use axum::{extract::State, http::StatusCode, Json};
-use shared::{DashboardStats, RevenuePoint};
+use shared::{DashboardStats, Member, RevenuePoint};
 use sqlx::Row;
 
 pub async fn stats(
@@ -55,6 +55,36 @@ pub async fn revenue(
         .collect();
 
     Ok(Json(points))
+}
+
+pub async fn members(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<Member>>, (StatusCode, String)> {
+    let rows = sqlx::query(
+        r#"
+        SELECT name, avatar_url, tier, joined_at
+        FROM members
+        ORDER BY joined_at DESC
+        "#,
+    )
+    .fetch_all(&state.pool)
+    .await
+    .map_err(internal_error)?;
+
+    let members = rows
+        .into_iter()
+        .map(|row| {
+            let joined_at: chrono::DateTime<chrono::Utc> = row.get("joined_at");
+            Member {
+                name: row.get("name"),
+                avatar_url: row.get("avatar_url"),
+                tier: row.get("tier"),
+                joined_at: joined_at.format("%b %-d, %Y").to_string(),
+            }
+        })
+        .collect();
+
+    Ok(Json(members))
 }
 
 fn internal_error(error: sqlx::Error) -> (StatusCode, String) {

--- a/backend/src/routes/dashboard.rs
+++ b/backend/src/routes/dashboard.rs
@@ -5,4 +5,5 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/stats", get(dashboard_handler::stats))
         .route("/revenue", get(dashboard_handler::revenue))
+        .route("/members", get(dashboard_handler::members))
 }

--- a/frontend/src/api/client.rs
+++ b/frontend/src/api/client.rs
@@ -1,5 +1,5 @@
 use reqwasm::http::Request;
-use shared::{DashboardStats, RevenuePoint};
+use shared::{DashboardStats, Member, RevenuePoint};
 
 const API_BASE: &str = "/api";
 
@@ -9,6 +9,10 @@ pub async fn fetch_stats() -> Result<DashboardStats, String> {
 
 pub async fn fetch_revenue() -> Result<Vec<RevenuePoint>, String> {
     fetch_json(&format!("{API_BASE}/dashboard/revenue")).await
+}
+
+pub async fn fetch_members() -> Result<Vec<Member>, String> {
+    fetch_json(&format!("{API_BASE}/dashboard/members")).await
 }
 
 async fn fetch_json<T>(url: &str) -> Result<T, String>

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::client::{fetch_revenue, fetch_stats},
+    api::client::{fetch_members, fetch_revenue, fetch_stats},
     components::{simple_chart::SimpleChart, stat_card::StatCard},
 };
 use leptos::*;
@@ -9,6 +9,7 @@ pub fn DashboardPage() -> impl IntoView {
     let stats = create_resource(|| (), |_| async { fetch_stats().await });
     let revenue = create_resource(|| (), |_| async { fetch_revenue().await });
     let (dark_mode, set_dark_mode) = create_signal(true);
+    let members = create_resource(|| (), |_| async { fetch_members().await });
 
     view! {
         <style>{include_str!("../styles.css")}</style>
@@ -125,6 +126,63 @@ pub fn DashboardPage() -> impl IntoView {
                         {move || {
                             revenue.get().map(|result| match result {
                                 Ok(points) => view! { <SimpleChart points=points /> }.into_view(),
+                                Err(error) => view! { <p class="text-red-600">{error}</p> }.into_view(),
+                            })
+                        }}
+                    </Suspense>
+                </section>
+
+                <section class="mt-3.5 rounded-lg border border-zinc-200 bg-white/95 p-5 shadow-[0_18px_60px_rgb(10_10_10_/_0.08)] dark:border-zinc-800 dark:bg-zinc-950/95 dark:shadow-[0_22px_70px_rgb(0_0_0_/_0.44)]">
+                    <div class="mb-5 flex items-start justify-between gap-3 max-sm:flex-col">
+                        <div>
+                            <p class="m-0 mb-2 text-xs font-extrabold uppercase tracking-normal text-zinc-500 dark:text-zinc-400">"Community"</p>
+                            <h2 class="m-0 text-[1.15rem] font-black tracking-normal">"Members"</h2>
+                        </div>
+                    </div>
+                    <Suspense fallback=move || view! { <p class="text-zinc-500 dark:text-zinc-400">"Loading members..."</p> }>
+                        {move || {
+                            members.get().map(|result| match result {
+                                Ok(members) => {
+                                    if members.is_empty() {
+                                        view! { <p class="text-zinc-500 dark:text-zinc-400">"No members yet."</p> }.into_view()
+                                    } else {
+                                        view! {
+                                            <div class="overflow-x-auto">
+                                                <table class="w-full text-left text-[0.88rem]">
+                                                    <thead>
+                                                        <tr class="border-b border-zinc-200 dark:border-zinc-800">
+                                                            <th class="pb-3 pr-4 text-[0.78rem] font-extrabold uppercase text-zinc-500 dark:text-zinc-400">"Name"</th>
+                                                            <th class="pb-3 pr-4 text-[0.78rem] font-extrabold uppercase text-zinc-500 dark:text-zinc-400">"Tier"</th>
+                                                            <th class="pb-3 text-[0.78rem] font-extrabold uppercase text-zinc-500 dark:text-zinc-400">"Joined"</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        {members.into_iter().map(|m| {
+                                                            let avatar = m.avatar_url.clone().unwrap_or_default();
+                                                            let has_avatar = !avatar.is_empty();
+                                                            view! {
+                                                                <tr class="border-b border-zinc-100 dark:border-zinc-800/50">
+                                                                    <td class="flex items-center gap-2.5 py-3 pr-4 font-bold">
+                                                                        {if has_avatar {
+                                                                            view! { <img class="h-7 w-7 rounded-full object-cover" src=avatar alt="" /> }.into_view()
+                                                                        } else {
+                                                                            view! { <span class="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-200 text-[0.7rem] font-bold text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">{m.name.chars().next().unwrap_or('?').to_string()}</span> }.into_view()
+                                                                        }}
+                                                                        {m.name}
+                                                                    </td>
+                                                                    <td class="py-3 pr-4">
+                                                                        <span class="rounded-full bg-zinc-100 px-2.5 py-1 text-[0.78rem] font-bold dark:bg-zinc-800">{m.tier}</span>
+                                                                    </td>
+                                                                    <td class="py-3 text-zinc-500 dark:text-zinc-400">{m.joined_at}</td>
+                                                                </tr>
+                                                            }
+                                                        }).collect_view()}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        }.into_view()
+                                    }
+                                },
                                 Err(error) => view! { <p class="text-red-600">{error}</p> }.into_view(),
                             })
                         }}

--- a/migrations/004_create_members.sql
+++ b/migrations/004_create_members.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS members (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    avatar_url TEXT,
+    tier TEXT NOT NULL,
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO members (name, avatar_url, tier, joined_at)
+VALUES
+    ('OrcDev',    'https://www.shipper.club/builders/orcdev.jpeg', 'Legend',  '2026-04-15T10:00:00Z'),
+    ('Alice',     NULL, 'Legend',  '2026-04-16T12:00:00Z'),
+    ('Bob',       NULL, 'Legend',  '2026-04-17T09:30:00Z'),
+    ('Charlie',   NULL, 'Legend',  '2026-04-18T14:00:00Z'),
+    ('Diana',     NULL, 'Legend',  '2026-04-19T11:15:00Z'),
+    ('Eve',       NULL, 'Builder', '2026-04-20T16:45:00Z'),
+    ('Frank',     NULL, 'Builder', '2026-04-21T08:00:00Z'),
+    ('Grace',     NULL, 'Builder', '2026-04-22T13:20:00Z'),
+    ('Hank',      NULL, 'Builder', '2026-04-23T10:50:00Z'),
+    ('Ivy',       NULL, 'Builder', '2026-04-24T15:00:00Z'),
+    ('Jack',      NULL, 'Starter', '2026-04-25T09:00:00Z'),
+    ('Karen',     NULL, 'Starter', '2026-04-26T12:30:00Z'),
+    ('Leo',       NULL, 'Starter', '2026-04-27T14:10:00Z'),
+    ('Mona',      NULL, 'Starter', '2026-04-28T11:00:00Z'),
+    ('Nick',      NULL, 'Starter', '2026-04-29T16:00:00Z'),
+    ('Olivia',    NULL, 'Starter', '2026-04-30T08:45:00Z')
+ON CONFLICT DO NOTHING;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod models;
 pub mod responses;
 
-pub use models::{DashboardStats, RevenuePoint};
+pub use models::{DashboardStats, Member, RevenuePoint};
 pub use responses::DashboardResponse;

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -15,3 +15,11 @@ pub struct RevenuePoint {
     pub date: NaiveDate,
     pub revenue_cents: i64,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Member {
+    pub name: String,
+    pub avatar_url: Option<String>,
+    pub tier: String,
+    pub joined_at: String,
+}


### PR DESCRIPTION
## Summary

Adds a full-stack member list feature — from database to API to UI.

Closes #7

## Changes

### Shared
- New `Member` struct with `name`, `avatar_url`, `tier`, `joined_at`

### Database
- Migration `004_create_members.sql` — creates `members` table
- Seeds 16 members across Legend/Builder/Starter tiers

### Backend
- New `members()` handler returning all members sorted by join date (newest first)
- New route: `GET /api/dashboard/members`
- Added `chrono` dependency for date formatting

### Frontend
- New `fetch_members()` API function
- Members table section below the revenue chart
- Avatar image with initial-letter fallback for members without avatars
- Tier badges with pill styling
- Loading and error states via Suspense

## Testing

- `cargo check -p shared -p backend` ✅
- `cargo check -p frontend --target wasm32-unknown-unknown` ✅
- `cargo fmt --all -- --check` ✅